### PR TITLE
Add support for flexible server and obtain runner's public IP address from ipify

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,15 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PsqlConstants = exports.FirewallConstants = exports.FileConstants = void 0;
+exports.PsqlConstants = exports.FileConstants = void 0;
 class FileConstants {
 }
 exports.FileConstants = FileConstants;
 // regex checks that string should end with .sql and if folderPath is present, * should not be included in folderPath
 FileConstants.singleParentDirRegex = /^((?!\*\/).)*(\.sql)$/g;
-class FirewallConstants {
-}
-exports.FirewallConstants = FirewallConstants;
-FirewallConstants.ipv4MatchPattern = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
 class PsqlConstants {
 }
 exports.PsqlConstants = PsqlConstants;

--- a/lib/Utils/FirewallUtils/ResourceManager.js
+++ b/lib/Utils/FirewallUtils/ResourceManager.js
@@ -46,31 +46,27 @@ class AzurePSQLResourceManager {
     getPSQLServer() {
         return this._resource;
     }
-    _populatePSQLServerData(serverName) {
+    _getPSQLServer(serverType, apiVersion, serverName) {
         return __awaiter(this, void 0, void 0, function* () {
-            // trim the cloud hostname suffix from servername
-            serverName = serverName.split('.')[0];
             const httpRequest = {
                 method: 'GET',
-                uri: this._restClient.getRequestUri('//subscriptions/{subscriptionId}/providers/Microsoft.DBforPostgreSQL/servers', {}, [], '2017-12-01')
+                uri: this._restClient.getRequestUri(`//subscriptions/{subscriptionId}/providers/Microsoft.DBforPostgreSQL/${serverType}`, {}, [], apiVersion)
             };
-            core.debug(`Get PSQL server '${serverName}' details`);
+            core.debug(`Get '${serverName}' for PSQL ${serverType} details`);
             try {
                 const httpResponse = yield this._restClient.beginRequest(httpRequest);
                 if (httpResponse.statusCode !== 200) {
                     throw AzureRestClient_1.ToError(httpResponse);
                 }
-                const sqlServers = httpResponse.body && httpResponse.body.value;
-                if (sqlServers && sqlServers.length > 0) {
-                    this._resource = sqlServers.filter((sqlResource) => sqlResource.name.toLowerCase() === serverName.toLowerCase())[0];
-                    if (!this._resource) {
-                        throw new Error(`Unable to get details of PSQL server ${serverName}. PSQL server '${serverName}' was not found in the subscription.`);
-                    }
-                    core.debug(JSON.stringify(this._resource));
+                const sqlServers = ((httpResponse.body && httpResponse.body.value) || []);
+                const sqlServer = sqlServers.find((sqlResource) => sqlResource.name.toLowerCase() === serverName.toLowerCase());
+                if (sqlServer) {
+                    this._serverType = serverType;
+                    this._apiVersion = apiVersion;
+                    this._resource = sqlServer;
+                    return true;
                 }
-                else {
-                    throw new Error(`Unable to get details of PSQL server ${serverName}. No PSQL servers were found in the subscription.`);
-                }
+                return false;
             }
             catch (error) {
                 if (error instanceof AzureRestClient_1.AzureError) {
@@ -80,12 +76,22 @@ class AzurePSQLResourceManager {
             }
         });
     }
+    _populatePSQLServerData(serverName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // trim the cloud hostname suffix from servername
+            serverName = serverName.split('.')[0];
+            (yield this._getPSQLServer('servers', '2017-12-01', serverName)) || (yield this._getPSQLServer('flexibleServers', '2021-06-01', serverName));
+            if (!this._resource) {
+                throw new Error(`Unable to get details of PSQL server ${serverName}. PSQL server '${serverName}' was not found in the subscription.`);
+            }
+        });
+    }
     addFirewallRule(startIpAddress, endIpAddress) {
         return __awaiter(this, void 0, void 0, function* () {
             const firewallRuleName = `ClientIPAddress_${Date.now()}`;
             const httpRequest = {
                 method: 'PUT',
-                uri: this._restClient.getRequestUri(`/${this._resource.id}/firewallRules/${firewallRuleName}`, {}, [], '2017-12-01'),
+                uri: this._restClient.getRequestUri(`/${this._resource.id}/firewallRules/${firewallRuleName}`, {}, [], this._apiVersion),
                 body: JSON.stringify({
                     'properties': {
                         'startIpAddress': startIpAddress,
@@ -122,7 +128,7 @@ class AzurePSQLResourceManager {
         return __awaiter(this, void 0, void 0, function* () {
             const httpRequest = {
                 method: 'GET',
-                uri: this._restClient.getRequestUri(`/${this._resource.id}/firewallRules/${ruleName}`, {}, [], '2017-12-01')
+                uri: this._restClient.getRequestUri(`/${this._resource.id}/firewallRules/${ruleName}`, {}, [], this._apiVersion)
             };
             try {
                 const httpResponse = yield this._restClient.beginRequest(httpRequest);
@@ -143,7 +149,7 @@ class AzurePSQLResourceManager {
         return __awaiter(this, void 0, void 0, function* () {
             const httpRequest = {
                 method: 'DELETE',
-                uri: this._restClient.getRequestUri(`/${this._resource.id}/firewallRules/${firewallRule.name}`, {}, [], '2017-12-01')
+                uri: this._restClient.getRequestUri(`/${this._resource.id}/firewallRules/${firewallRule.name}`, {}, [], this._apiVersion)
             };
             try {
                 const httpResponse = yield this._restClient.beginRequest(httpRequest);

--- a/lib/Utils/PsqlUtils/PsqlUtils.js
+++ b/lib/Utils/PsqlUtils/PsqlUtils.js
@@ -13,10 +13,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const Constants_1 = require("../../Constants");
-const Constants_2 = require("../../Constants");
 const PsqlToolRunner_1 = __importDefault(require("./PsqlToolRunner"));
+const http_client_1 = require("@actions/http-client");
 class PsqlUtils {
     static detectIPAddress(connectionString) {
+        var _a;
         return __awaiter(this, void 0, void 0, function* () {
             let psqlError = '';
             let ipAddress = '';
@@ -33,14 +34,15 @@ class PsqlUtils {
                 yield PsqlToolRunner_1.default.init();
                 yield PsqlToolRunner_1.default.executePsqlCommand(connectionString, Constants_1.PsqlConstants.SELECT_1, options);
             }
-            catch (err) {
+            catch (_b) {
                 if (psqlError) {
-                    const ipAddresses = psqlError.match(Constants_2.FirewallConstants.ipv4MatchPattern);
-                    if (ipAddresses) {
-                        ipAddress = ipAddresses[0];
+                    const http = new http_client_1.HttpClient();
+                    try {
+                        const ipv4 = yield http.getJson('https://api.ipify.org?format=json');
+                        ipAddress = ((_a = ipv4.result) === null || _a === void 0 ? void 0 : _a.ip) || '';
                     }
-                    else {
-                        throw new Error(`Unable to detect client IP Address: ${psqlError}`);
+                    catch (err) {
+                        throw new Error(`Unable to detect client IP Address: ${err.message}`);
                     }
                 }
             }

--- a/lib/Utils/PsqlUtils/PsqlUtils.js
+++ b/lib/Utils/PsqlUtils/PsqlUtils.js
@@ -32,7 +32,7 @@ class PsqlUtils {
             // "SELECT 1" psql command is run to check if psql client is able to connect to DB using the connectionString
             try {
                 yield PsqlToolRunner_1.default.init();
-                yield PsqlToolRunner_1.default.executePsqlCommand(connectionString, Constants_1.PsqlConstants.SELECT_1, options);
+                yield PsqlToolRunner_1.default.executePsqlCommand(`${connectionString} connect_timeout=10`, Constants_1.PsqlConstants.SELECT_1, options);
             }
             catch (_b) {
                 if (psqlError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,14 @@
         "@actions/io": "^1.0.1"
       }
     },
+    "@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "requires": {
+        "tunnel": "^0.0.6"
+      }
+    },
     "@actions/io": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
+    "@actions/http-client": "^2.0.1",
     "@actions/io": "^1.0.2",
     "azure-actions-webclient": "^1.0.11",
     "crypto": "^1.0.1",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -3,10 +3,6 @@ export class FileConstants {
     static readonly singleParentDirRegex = /^((?!\*\/).)*(\.sql)$/g;
 }
 
-export class FirewallConstants {
-    static readonly ipv4MatchPattern = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
-}
-
 export class PsqlConstants {
     static readonly SELECT_1 = "SELECT 1";
     // host, port, dbname, user, password must be present in connection string in any order.

--- a/src/Utils/PsqlUtils/PsqlUtils.ts
+++ b/src/Utils/PsqlUtils/PsqlUtils.ts
@@ -14,10 +14,11 @@ export default class PsqlUtils {
             }, 
             silent: true
         };
+
         // "SELECT 1" psql command is run to check if psql client is able to connect to DB using the connectionString
         try {
             await PsqlToolRunner.init();
-            await PsqlToolRunner.executePsqlCommand(connectionString, PsqlConstants.SELECT_1, options);
+            await PsqlToolRunner.executePsqlCommand(`${connectionString} connect_timeout=10`, PsqlConstants.SELECT_1, options);
         } catch {
             if (psqlError) {
                 const http = new HttpClient();
@@ -31,7 +32,6 @@ export default class PsqlUtils {
         }
         return ipAddress;
     }
-
 }
 
 export interface IPResponse {

--- a/src/__tests__/Utils/ResourceManager.test.ts
+++ b/src/__tests__/Utils/ResourceManager.test.ts
@@ -1,0 +1,225 @@
+import { IAuthorizer } from 'azure-actions-webclient/Authorizer/IAuthorizer';
+import { ServiceClient as AzureRestClient } from 'azure-actions-webclient/AzureRestClient';
+import AzurePSQLResourceManager, { FirewallRule } from '../../Utils/FirewallUtils/ResourceManager';
+
+jest.mock('azure-actions-webclient/AzureRestClient');
+
+describe('Testing ResourceManager', () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('Initializes resource manager correctly for single server', async () => {
+        let getRequestUrlSpy = jest.spyOn(AzureRestClient.prototype, 'getRequestUri').mockReturnValue('https://randomUrl/');
+        let beginRequestSpy = jest.spyOn(AzureRestClient.prototype, 'beginRequest').mockResolvedValue({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer1',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer1'
+                    },
+                    {
+                        name: 'testServer2',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer2'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        });
+
+        let resourceManager = await AzurePSQLResourceManager.getResourceManager('testServer1', {} as IAuthorizer);
+        let server = resourceManager.getPSQLServer();
+
+        expect(server!.name).toEqual('testServer1');
+        expect(server!.id).toEqual('/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer1');
+        expect(getRequestUrlSpy).toHaveBeenCalledTimes(1);
+        expect(beginRequestSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Initializes resource manager correctly for flexible server', async () => {
+        let getRequestUrlSpy = jest.spyOn(AzureRestClient.prototype, 'getRequestUri').mockReturnValue('https://randomUrl/');
+        let beginRequestSpy = jest.spyOn(AzureRestClient.prototype, 'beginRequest').mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer1',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer1'
+                    },
+                    {
+                        name: 'testServer2',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer2'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        }).mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer3',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/flexibleServers/testServer3'
+                    },
+                    {
+                        name: 'testServer4',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/flexibleServers/testServer4'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        });
+
+        let resourceManager = await AzurePSQLResourceManager.getResourceManager('testServer4', {} as IAuthorizer);
+        let server = resourceManager.getPSQLServer();
+
+        expect(server!.name).toEqual('testServer4');
+        expect(server!.id).toEqual('/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/flexibleServers/testServer4');
+        expect(getRequestUrlSpy).toHaveBeenCalledTimes(2);
+        expect(beginRequestSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('Throws if the server does not exist', async () => {
+        let getRequestUrlSpy = jest.spyOn(AzureRestClient.prototype, 'getRequestUri').mockReturnValue('https://randomUrl/');
+        let beginRequestSpy = jest.spyOn(AzureRestClient.prototype, 'beginRequest').mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer1',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer1'
+                    },
+                    {
+                        name: 'testServer2',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer2'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        }).mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer3',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/flexibleServers/testServer3'
+                    },
+                    {
+                        name: 'testServer4',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/flexibleServers/testServer4'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        });
+
+        let expectedError = `Unable to get details of PSQL server testServer5. PSQL server 'testServer5' was not found in the subscription.`;
+        try {
+            await AzurePSQLResourceManager.getResourceManager('testServer5', {} as IAuthorizer);
+        } catch(error) {
+            expect(error.message).toEqual(expectedError);
+        }
+        expect(getRequestUrlSpy).toHaveBeenCalledTimes(2);
+        expect(beginRequestSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('Adds firewall rule successfully', async () => {
+        let getRequestUrlSpy = jest.spyOn(AzureRestClient.prototype, 'getRequestUri').mockReturnValue('https://randomUrl/');
+        let beginRequestSpy = jest.spyOn(AzureRestClient.prototype, 'beginRequest').mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer1',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer1'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        }).mockResolvedValueOnce({
+            statusCode: 202,
+            body: {},
+            statusMessage: 'OK',
+            headers: {
+                'azure-asyncoperation': 'http://asyncRedirectionURI'
+            }
+        }).mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                'status': 'Succeeded'
+            },
+            statusMessage: 'OK',
+            headers: {}
+        }).mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                name: 'FirewallRule'
+            },
+            statusMessage: 'OK',
+            headers: {}
+        });
+        
+        let resourceManager = await AzurePSQLResourceManager.getResourceManager('testServer1', {} as IAuthorizer);
+        let firewallRule = await resourceManager.addFirewallRule('0.0.0.0', '1.1.1.1');
+
+        expect(firewallRule.name).toEqual('FirewallRule');
+        expect(getRequestUrlSpy).toHaveBeenCalledTimes(3);
+        expect(beginRequestSpy).toHaveBeenCalledTimes(4);
+    });
+
+    it('Removes firewall rule successfully', async () => {
+        let getRequestUrlSpy = jest.spyOn(AzureRestClient.prototype, 'getRequestUri').mockReturnValue('https://randomUrl/');
+        let beginRequestSpy = jest.spyOn(AzureRestClient.prototype, 'beginRequest').mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer1',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/testServer1'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        }).mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                value: [
+                    {
+                        name: 'testServer3',
+                        id: '/subscriptions/SubscriptionId/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/flexibleServers/testServer3'
+                    }
+                ]
+            },
+            statusMessage: 'OK',
+            headers: []
+        }).mockResolvedValueOnce({
+            statusCode: 202,
+            body: {},
+            statusMessage: 'OK',
+            headers: {
+                'azure-asyncoperation': 'http://asyncRedirectionURI'
+            }
+        }).mockResolvedValueOnce({
+            statusCode: 200,
+            body: {
+                'status': 'Succeeded'
+            },
+            statusMessage: 'OK',
+            headers: {}
+        });
+
+        let resourceManager = await AzurePSQLResourceManager.getResourceManager('testServer3', {} as IAuthorizer);
+        await resourceManager.removeFirewallRule({ name: 'FirewallRule' } as FirewallRule);
+
+        expect(getRequestUrlSpy).toHaveBeenCalledTimes(3);
+        expect(beginRequestSpy).toHaveBeenCalledTimes(4);
+    })
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2020.string"],                 /* Specify library files to be included in the compilation. */
+    "lib": ["es2020.string", "dom"],          /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
This PR adds support for PostgreSQL flexible server when it's needed to add a temporal firewall rule so the runner can connect to the database server.

Also, this PR solves https://github.com/Azure/postgresql/issues/24. When the runner doesn't have access to the PostgreSQL database tries to obtain its own public IP address from the error message that `psql` returns. But the structure of those messages varies in content, and we aren't guaranteed that the actual public IP address will be on it. Examples:

1. Flexible server:
```
psql: error: connection to server at "***.postgres.database.azure.com" (1.2.3.4), port 5432 failed: Connection timed out
Is the server running on that host and accepting TCP/IP connections?
```
In this case the IP `1.2.3.4` corresponds to the database server and not the runner.

2. Single server
```
psql: error: connection to server at "***.postgres.database.azure.com" (1.2.3.4), port 5432 failed: FATAL:  no pg_hba.conf entry for host "5.6.7.8", user "alaneos777", database "test", SSL on
```
In this case the IP address of the runner is `5.6.7.8`, but we can't guarantee if it will come before or after the other IP `1.2.3.4`.

So, the proposed solution is to obtain the public IP address of the runner using the service from `https://api.ipify.org?format=json`. By doing this, we don't depend on the structure of the error message that `psql` returns.